### PR TITLE
Remove `noarch_python` as it is unsupported

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,7 @@ package:
   version: 3.0
 
 build:
-  noarch_python: True
-  number: 0
+  number: 1
 
 requirements:
   run:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pyomo.extras-feedstock/issues/1

Simply drops the `noarch_python` portion and bumps the build number. Attempted to re-render, but that had no effect.

cc @whart222 @pelson