### PR TITLE
Updating the build number.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: 3.0
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
The last update didn't update the build number, which
we need to do to force a rebuild of the conda packages.